### PR TITLE
[Doctrine] Fixed a memory leak

### DIFF
--- a/Adapter/DoctrineAdapter.php
+++ b/Adapter/DoctrineAdapter.php
@@ -450,12 +450,14 @@ class DoctrineAdapter extends AbstractAdapter implements AdapterInterface
         $sql = 'SELECT m '.
             'FROM Heri\Bundle\JobQueueBundle\Entity\Message m '.
             'LEFT JOIN m.queue q '.
-            'WHERE (m.handle IS NULL OR m.handle = \'\' OR m.timeout + '.
-            (int) $timeout.' < '.(int) $microtime.') '.$andWhere.' '.
+            'WHERE (m.handle IS NULL OR m.handle = \'\' OR m.timeout + :timeout < :microtime) '.$andWhere.' '.
             'ORDER BY m.priority DESC';
 
         $query = $this->em->createQuery($sql);
-
+        
+        $query->setParameter('timeout', (int)$timeout);
+        $query->setParameter('microtime', (int)$microtime);
+        
         if ($queue instanceof Queue) {
             $query->setParameter('queue', $this->getQueueEntity($queue->getName()));
         }


### PR DESCRIPTION
Using string concatenation for SQL-query composing leads to a memory leak since the value of $microtime is unique for every call what leads to a flooding of the doctrine query cache with unused  query objects. Using proper placeholders for the changing parts of a query fixes this.